### PR TITLE
11.16: added github-tag-action for release version, DRY_RUN

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,3 +40,11 @@ jobs:
           checkstring: "ok"
           rollbackonhealthcheckfailed: true
         if: ${{ github.event_name == 'push' }}
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.26.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch
+          DRY_RUN: true
+        if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
should not give out a version, nor should be run until merging into master